### PR TITLE
Add release to rocks create mirror

### DIFF
--- a/src/rocks-pylib/rocks/commands/create/mirror/__init__.py
+++ b/src/rocks-pylib/rocks/commands/create/mirror/__init__.py
@@ -172,15 +172,19 @@ class Command(rocks.commands.create.command):
 	Rocks running on this machine).
 	</param>
 
+	<param type='string' name='release'>
+	The release number of the created Roll. (default = 0).
+	</param>
+
 	<param type='string' name='arch'>
 	Architecture of the mirror. (default = the architecture of 
 	of the OS running on this machine).
 	</param>
 
-	<example cmd='create mirror http://mirrors.kernel.org/centos/4.5/updates/i386/RPMS rollname=updates version=4.5'>
+	<example cmd='create mirror http://mirrors.kernel.org/centos/6.6/updates/x86_64/Packages rollname=updates version=6.6 release=2015.01.29'>
 	Will mirror all the packages found under the URL
-	http://mirrors.kernel.org/centos/4.5/updates/i386/RPMS and will create
-	a Roll ISO image named 'updates-4.5-0.i386.disk1.iso'.
+	http://mirrors.kernel.org/centos/6.6/updates/x86_64/Packages and will create
+	a Roll ISO image named 'updates-6.6-2015.01.29.x86_64.disk1.iso'.
 	</example>
 	"""
 
@@ -200,7 +204,7 @@ class Command(rocks.commands.create.command):
 		os.symlink(mirrordir, 'RPMS')
 
 
-	def makeRollXML(self, rollname, version, arch, xmlfilename):
+	def makeRollXML(self, rollname, version, release, arch, xmlfilename):
 		file = open(xmlfilename, 'w')
 		file.write('<roll name="%s" interface="4.0">\n' % rollname)
 
@@ -211,8 +215,8 @@ class Command(rocks.commands.create.command):
 			(rolltime, rolldate, rollzone))
 
 		file.write('\t<color edge="lawngreen" node="lawngreen"/>\n')
-		file.write('\t<info version="%s" release="0" arch="%s"/>\n' % 
-			(version, arch))
+		file.write('\t<info version="%s" release="%s" arch="%s"/>\n' % 
+			(version, release, arch))
 
 		file.write('\t<iso maxsize="0" bootable="0" mkisofs=""/>\n')
 		file.write('\t<rpm rolls="0" bin="1" src="0"/>/\n')
@@ -232,9 +236,10 @@ class Command(rocks.commands.create.command):
 			self.abort('must supply one path')
 		mirror_path = args[0]
 		
-		(rollname, version, arch) = self.fillParams(
+		(rollname, version, release, arch) = self.fillParams(
 			[('rollname', 'updates'),
 			('version', rocks.version),
+			('release', '0'),
 			('arch',self.arch)])
 
 		xmlfilename = 'roll-%s.xml' % rollname
@@ -242,7 +247,7 @@ class Command(rocks.commands.create.command):
 		self.clean()
 		
 		self.mirror(mirror_path)
-		self.makeRollXML(rollname, version, arch, xmlfilename)
+		self.makeRollXML(rollname, version, release, arch, xmlfilename)
 		
 		self.command('create.roll', [ '%s' % (xmlfilename) ] )
 		

--- a/src/rocks-pylib/rocks/commands/create/mirror/__init__.py
+++ b/src/rocks-pylib/rocks/commands/create/mirror/__init__.py
@@ -190,7 +190,7 @@ class Command(rocks.commands.create.command):
 
 
 	def mirror(self, mirror_path):
-		cmd = 'wget -erobots=off --reject "anaconda*rpm" -m -nv -np %s' % (mirror_path)
+		cmd = 'wget -erobots=off --reject "anaconda*rpm,drpm" -m -nv -np %s' % (mirror_path)
 		os.system(cmd)
 
 		if len(mirror_path) > 6:


### PR DESCRIPTION
- Makes tracking different updates ISO's a bit easier...

```
$ cat roll-Updates-CentOS.xml
<roll name="Updates-CentOS" interface="4.0">
    <timestamp time="21:59:41" date="Jun 01 2015" tz="PDT"/>
    <color edge="lawngreen" node="lawngreen"/>
    <info version="6.6" release="2015.06.01" arch="x86_64"/>
    <iso maxsize="0" bootable="0" mkisofs=""/>
    <rpm rolls="0" bin="1" src="0"/>/
</roll>

$ ls *.iso
Updates-CentOS-6.6-2015.06.01.x86_64.disk1.iso
```
- No change to ISO naming if `release` isn't provided.
- Prevents downloading of drpm packages which are never included anyway making mirror process faster.
