### PR TITLE
swap two cmd in sync/host/sec_attr/__init__.py

### DIFF
--- a/src/rocks-pylib/rocks/commands/sync/host/sec_attr/__init__.py
+++ b/src/rocks-pylib/rocks/commands/sync/host/sec_attr/__init__.py
@@ -154,12 +154,12 @@ class Command(rocks.commands.sync.host.command):
 
 			# Ship the pickled file to destination host
 			cmd = 'scp -q -o UserKnownHostsFile=%s %s %s:%s; ' % (khfname, fname, host, fname)
-			# Remove the file from the frontend
-			cmd = cmd + 'rm -rf %s; ' % (fname)
 			# Run the unpickle procedure and run the plugin
 			cmd = cmd + 'ssh -o UserKnownHostsFile=%s %s ' % (khfname,host)	+\
 				'"/opt/rocks/bin/rocks '+\
 				'run host sec_attr %s"' % (fname)
+			# Remove the file from the frontend
+			cmd = cmd + ';rm -rf %s ' % (fname)
 			p = Parallel(cmd, host)
 			p.start()
 			threads.append(p)


### PR DESCRIPTION
swapping the rm to the end will allow to run 'sync host sec_attr 'on the frontend itself unless is forbidden by design.