### PR TITLE
Update default_md in ca.xml for newer openssl

### DIFF
--- a/nodes/ca.xml
+++ b/nodes/ca.xml
@@ -104,7 +104,7 @@ mkdir -p /etc/security/ca/new-certs
 <file name="/etc/security/ca/ca.cfg" perms="0640" owner="root.apache">
 [ req ]
 default_bits		= 1024
-default_md		= md5
+default_md		= 3des
 string_mask		= nombstr	# permitted characters
 distinguished_name	= req_distinguished_name
 


### PR DESCRIPTION
Newer versions of openssl do not support md5 as cipher. 3des is supported. Changing to 3des in the ca.cfg file allows creation of localhost.crt and use of central server in Rocks 6.2 installed with CentOS 6.9 which includes updated openssl.