### PR TITLE
ROCKS7: Don't sync service accounts with 411 and/or add to google-otp group

### DIFF
--- a/nodes/google-otp-server.xml
+++ b/nodes/google-otp-server.xml
@@ -22,8 +22,15 @@
   </changelog>
 
 <post>
+<post cond="rocks_version_major == 7">
+getent group google-otp &gt;/dev/null || groupadd -r google-otp
+</post>
 
+<post cond="rocks_version_major == 6">
 /usr/sbin/groupadd -g 426 google-otp
+</post>
+
+<post>
 /opt/rocks/bin/rocks add attr Info_GoogleOTPUsers yes
 /opt/rocks/bin/rocks add attr Info_GoogleOTPRoot yes
 

--- a/src/411-master/plugins/group.py
+++ b/src/411-master/plugins/group.py
@@ -124,7 +124,7 @@ class Plugin(rocks.service411.Plugin):
 		content = content.rstrip('\n')
 		content_lines = content.split('\n')
 
-		# Get all groups greater than 500
+		# Get all groups greater than 1000
 		# except for groups.
 		group_list = ''
 		for line in content_lines:
@@ -132,13 +132,13 @@ class Plugin(rocks.service411.Plugin):
 			entry = line.split(':')
 			gid = int(entry[2])
 			groupname = entry[0].strip()
-			if gid >= 500 and \
+			if gid >= 1000 and \
 				groupname not in avoid_gname:
 				group_list = group_list + line + '\n'
 
 		# Open the group file. and read 
 		# it's contents, so that we can
-		# maintain the UID's less than 500
+		# maintain the UID's less than 1000
 		# Also maintain all groupnames like
 		# nobody, nobody4, etc for solaris
 		f = open('/etc/group', 'r')
@@ -149,7 +149,7 @@ class Plugin(rocks.service411.Plugin):
 			group_entry = line.split(':')
 			gid = int(group_entry[2])
 			groupname = group_entry[0].strip()
-			if gid < 500 or groupname in avoid_gname:
+			if gid < 1000 or groupname in avoid_gname:
 				group_lines = group_lines + line + '\n'
 		f.close()
 

--- a/src/411-master/plugins/passwd.py
+++ b/src/411-master/plugins/passwd.py
@@ -137,7 +137,7 @@ class Plugin(rocks.service411.Plugin):
 		return lambda(x): (x.split(':')[0].strip(), x)
 
 	# List of usernames to avoid transferring
-	# that may have UIDs greater than 500
+	# that may have UIDs greater than 1000
 	@staticmethod
 	def avoid_uname():
 		return [
@@ -155,15 +155,16 @@ class Plugin(rocks.service411.Plugin):
 		lp = filter(self.filter_malformed(), content_lines)
 
 		# Get a list of all usernames in passwd file
-		# and keep only those whose UID >= 500
+		# and keep only those whose UID >= 1000
+        # UID_MIN == 1000 from /etc/login.defs
 		lp = filter(self.uid_f, lp)
 
 		return string.join(lp, '\n')
 
-	# Function that returns true if UID >= 500
+	# Function that returns true if UID >= 1000
 	def uid_f(self, x):
 		l = x.split(':')
-		if int(l[2]) < 500:
+		if int(l[2]) < 1000:
 			return False
 		if l[0] in self.avoid_uname():
 			return False
@@ -193,10 +194,10 @@ class Plugin(rocks.service411.Plugin):
 
 		for line in lp:
 			u_name = line.split(':')[0].strip()
-			# If we're under 500, add the line
+			# If we're under 1000, add the line
 			if not self.uid_f(line):
 				new_pw.append(line)
-			# If we're over UID 500, and present
+			# If we're over UID 1000, and present
 			# in the received passwd lines, then add
 			else:
 				if passwd_recv.has_key(u_name):

--- a/src/google-otp/plugin_googleotp.py
+++ b/src/google-otp/plugin_googleotp.py
@@ -74,7 +74,7 @@ class Plugin(rocks.commands.Plugin):
 			return 0
 
 	def run(self, args):
-		# scan the password for users >= 500  
+		# scan the password for users >= 1000
 		# this is the default entry as setup by useradd
 		otp_users = []
 		userOTP = self.db.getHostAttr('localhost', 'Info_GoogleOTPUsers')
@@ -89,8 +89,8 @@ class Plugin(rocks.commands.Plugin):
 				username = l[0]
 				uid = int(l[2])
 
-				# only users in Range
-				if uid >= 500 and uid < 65534: 
+				# only users in Range (UID_MIN and UID_MAX from /etc/login.defs)
+				if uid >= 1000 and uid < 60000:
 					otp_users.append(username)
 				file.close()
 


### PR DESCRIPTION
RHEL and CentOS 7 increase the UID_MIN value from 500 to 1000. Without this change service accounts in the range 500 < UID|GID < 1000 are synced from the frontend to the compute nodes, possibly breaking services on compute nodes. Additionally, service accounts in this range are added to the google-otp group by `rocks sync users`.