### PR TITLE
Use libwrap with *channel RPC services

### DIFF
--- a/src/channel/Makefile
+++ b/src/channel/Makefile
@@ -112,7 +112,7 @@ CFLAGS		= -g
 ifeq ($(OS), linux)
 CFLAGS		+= -Wall 
 CPPFLAGS	= -I/opt/rocks/include
-LDFLAGS		= -L/opt/rocks/lib -lrocks
+LDFLAGS		= -L/opt/rocks/lib -lrocks -lwrap
 
 ifeq ($(strip $(VERSION.MAJOR)), 6)
 #Centos 6.* libtirpc-0.2.1 are bugged cannot get return value from the server
@@ -123,9 +123,10 @@ endif
 
 ifeq ($(OS), sunos)
 CFLAGS		+= -m64
-LDFLAGS		+= -lrpcsvc -lnsl
+LDFLAGS		+= -lrpcsvc -lnsl -lwrap
 endif
 
+CFLAGS		+= -DSERVICE_NAME=\"channeld\"
 
 #	rpcgen -h -N -o channel.h $@
 

--- a/src/channel/server.c
+++ b/src/channel/server.c
@@ -118,7 +118,6 @@
 
 #if defined (__linux__)
 #include <rpc/pmap_clnt.h>
-#include <rocks/hexdump.h>
 #endif
 
 #if defined (__SVR4) && defined (__sun)
@@ -135,6 +134,10 @@ int _rpcpmstart;
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <netdb.h>
+#include <tcpd.h>
 
 void writePidFile(char * pidfile, int pid)
 {
@@ -160,13 +163,69 @@ extern void channel_prog_1(struct svc_req *rqstp, register SVCXPRT *transp);
 # define RPC_SERVICE(a)   a
 #endif
 
+/*
+ * returns nonzero if tcpd/libwrap allows this connection
+ * returns 0 if tcpd/libwrap denies this connection
+ */
+int 
+tcpd_allowed(struct svc_req *rqstp)
+{
+	static char remhost[1024];
+	int result;
+
+	assert(rqstp);
+	assert(rqstp->rq_xprt);
+
+	/* get the hostname from the IP */
+	result = getnameinfo((struct sockaddr *) &(rqstp->rq_xprt->xp_raddr), 
+	                     rqstp->rq_xprt->xp_addrlen, remhost, 1024, 
+			     NULL, 0, 0);
+
+	/* stop here if getnameinfo blew up */
+	if( result && result != EAI_AGAIN && result != EAI_NONAME ) {
+		syslog(LOG_DEBUG,"getnameinfo(%s) failed: %s",
+		       inet_ntoa(rqstp->rq_xprt->xp_raddr.sin_addr),
+		       strerror(result));
+		return 0;
+	}
+
+	/* do the libwrap check */
+	result = hosts_ctl(SERVICE_NAME, remhost,
+	                   inet_ntoa(rqstp->rq_xprt->xp_raddr.sin_addr),
+		           STRING_UNKNOWN);
+	if ( result ) return result; 
+       
+	/* report failures */
+	syslog(LOG_DEBUG,"hosts_ctl(\"%s\",%s,%s) rejected connection",
+	       SERVICE_NAME, remhost,
+  	       inet_ntoa(rqstp->rq_xprt->xp_raddr.sin_addr));
+ 
+       return 0;
+} /* tcpd_allowed */
+
+
 int *
 RPC_SERVICE(channel_ping_1)(struct svc_req *rqstp)
 {
-	static int  result = 1;
+	/* return 0 so RPC doesn't get upset */
+	static int  result = 0;
 
 	assert(rqstp);
 	syslog(LOG_DEBUG, "ping received");
+
+	/* libwrap check - stop as soon as possible if we shouldn't talk to
+	 * this host. 
+	 */
+	if(!tcpd_allowed(rqstp)) 
+	{
+		result = 0;
+		return &result; 
+	}
+
+	syslog(LOG_DEBUG, "ping received, socket %d clnt %s:%d", 
+	       rqstp->rq_xprt->xp_sock,
+	       inet_ntoa(rqstp->rq_xprt->xp_raddr.sin_addr),
+	       ntohs(rqstp->rq_xprt->xp_raddr.sin_port));
 
 	return &result;
 } /* channel_ping_1_svc */
@@ -187,6 +246,15 @@ RPC_SERVICE(channel_411_alert_1)(char *filename, char *signature,
 	assert(signature);
 	assert(time > 0);
 	assert(rqstp);
+
+	/* libwrap check - stop as soon as possible if we shouldn't talk to 
+	 * this host.
+	 */
+	if ( !tcpd_allowed(rqstp) )
+	{
+		result = 0;
+		return &result;
+	}
 
 	syslog(LOG_DEBUG, "411_alert received (file=\"%s\", time=%.6f)", filename, time);
 
@@ -231,7 +299,7 @@ main(int argc, char *argv[])
 	int pid;
 	register SVCXPRT *transp;
 
-	openlog("channeld", LOG_PID, LOG_LOCAL0);
+	openlog(SERVICE_NAME, LOG_PID, LOG_LOCAL0);
 	syslog(LOG_INFO, "starting service");
 
 #if defined (__SVR4) && defined (__sun)

--- a/src/sec-channel/server/Makefile
+++ b/src/sec-channel/server/Makefile
@@ -79,6 +79,9 @@ REDHAT.ROOT =	$(CURDIR)/../../../
 -include $(ROCKSROOT)/etc/Rules.mk
 include Rules.mk
 
+CFLAGS += -DSERVICE_NAME=\"sec_channel_server\"
+CFLAGS += -lwrap
+
 sec_channel.h:sec_channel.x
 	rpcgen -h -N -o $@ $^
 	sed -i sec_channel.h -e 's/sec_channel_ping_1_svc(int/sec_channel_ping_1_svc(int*/'

--- a/src/sec-channel/server/sec_channel_server.c
+++ b/src/sec-channel/server/sec_channel_server.c
@@ -92,11 +92,60 @@
 #include "sec_channel.h"
 #include <stdlib.h>
 #include <unistd.h>
+#include <assert.h>
 
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <arpa/inet.h>
 #include <signal.h>
+
+#include <netinet/in.h>
+#include <netdb.h>
+#include <tcpd.h>
+
+#include <syslog.h>
+
+
+/*
+ * returns nonzero if tcpd/libwrap allows this connection
+ * returns 0 if tcpd/libwrap denies this connection
+ */
+int 
+tcpd_allowed(struct svc_req *rqstp)
+{
+	static char remhost[1024];
+	int result;
+
+	assert(rqstp);
+	assert(rqstp->rq_xprt);
+
+	/* get the hostname from the IP */
+	result = getnameinfo((struct sockaddr *) &(rqstp->rq_xprt->xp_raddr), 
+	                     rqstp->rq_xprt->xp_addrlen, remhost, 1024, 
+			     NULL, 0, 0);
+
+	/* stop here if getnameinfo blew up */
+	if( result && result != EAI_AGAIN && result != EAI_NONAME ) {
+		syslog(LOG_DEBUG,"getnameinfo(%s) failed: %s",
+		       inet_ntoa(rqstp->rq_xprt->xp_raddr.sin_addr),
+		       strerror(result));
+		return 0;
+	}
+
+	/* do the libwrap check */
+	result = hosts_ctl(SERVICE_NAME, remhost,
+	                   inet_ntoa(rqstp->rq_xprt->xp_raddr.sin_addr),
+		           STRING_UNKNOWN);
+	if ( result ) return result; 
+       
+	/* report failures */
+	syslog(LOG_DEBUG,"hosts_ctl(\"%s\",%s,%s) rejected connection",
+	       SERVICE_NAME, remhost,
+  	       inet_ntoa(rqstp->rq_xprt->xp_raddr.sin_addr));
+ 
+       return 0;
+} /* tcpd_allowed */
+
 
 int *
 sec_channel_ping_1_svc(int *argp, struct svc_req *rqstp)
@@ -106,6 +155,15 @@ sec_channel_ping_1_svc(int *argp, struct svc_req *rqstp)
 	char *ipaddr;
 	int status;
 	int pid;
+
+	/* libwrap check - stop as soon as possible if we shouldn't talk to
+	 * this host. 
+	 */
+	if(!tcpd_allowed(rqstp)) 
+	{
+		result = 0;
+		return &result; 
+	}
 
 	switch(pid = fork()){
 		case -1:		/*Fork failed*/
@@ -122,6 +180,8 @@ sec_channel_ping_1_svc(int *argp, struct svc_req *rqstp)
 	addr = &rqstp->rq_xprt->xp_raddr;
 	ipaddr = (char *)malloc(sizeof(char)*INET_ADDRSTRLEN);
 	ipaddr = (char *)inet_ntop(AF_INET, &addr->sin_addr, ipaddr, INET_ADDRSTRLEN);
+
+	syslog(LOG_DEBUG, "Received request from %s", ipaddr);
 	fprintf(stderr, "Received request from %s\n", ipaddr);
 	if (*argp == 0)
 		status = execl("/opt/rocks/bin/rocks", "rocks",

--- a/src/sec-channel/server/sec_channel_svc.c
+++ b/src/sec-channel/server/sec_channel_svc.c
@@ -17,6 +17,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
+#include <syslog.h>
 
 
 
@@ -99,25 +100,36 @@ main (int argc, char **argv)
 			default:  break;
 		}
 	}
+
+	openlog(SERVICE_NAME, LOG_PID, LOG_LOCAL0);
+	syslog(LOG_INFO, "starting service");
+
 	pmap_unset (SEC_CHANNEL, SEC_CHANNEL_VERS);
 
 	transp = svcudp_create(RPC_ANYSOCK);
 	if (transp == NULL) {
 		fprintf (stderr, "%s", "cannot create udp service.");
+		syslog (LOG_ERR, "%s", "cannot create tcp service.");
 		exit(1);
 	}
 	if (!svc_register(transp, SEC_CHANNEL, SEC_CHANNEL_VERS, sec_channel_1, IPPROTO_UDP)) {
 		fprintf (stderr, "%s", "unable to register (SEC_CHANNEL, SEC_CHANNEL_VERS, udp).");
+		syslog (LOG_ERR, "%s",
+			"unable to register (SEC_CHANNEL, SEC_CHANNEL_VERS, udp)");
 		exit(1);
 	}
 
 	transp = svctcp_create(RPC_ANYSOCK, 0, 0);
 	if (transp == NULL) {
 		fprintf (stderr, "%s", "cannot create tcp service.");
+		syslog (LOG_ERR, "%s", "cannot create tcp service.");
 		exit(1);
 	}
 	if (!svc_register(transp, SEC_CHANNEL, SEC_CHANNEL_VERS, sec_channel_1, IPPROTO_TCP)) {
 		fprintf (stderr, "%s", "unable to register (SEC_CHANNEL, SEC_CHANNEL_VERS, tcp).");
+		syslog(LOG_ERR, "%s",
+		       "unable to register (SEC_CHANNEL, SEC_CHANNEL_VERS, tcp)");
+
 		exit(1);
 	}
 
@@ -151,6 +163,7 @@ main (int argc, char **argv)
 	fprintf(stdout, "Starting SVC_RUN loop\n");
 	svc_run();
 	fprintf (stderr, "%s", "svc_run returned");
+	syslog (LOG_ERR, "%s", "svc_run returned");
 	exit (1);
 	/* NOTREACHED */
 }


### PR DESCRIPTION
These services get dropped on random ports, making it hard to apply
firewall rules.  Use libwrap / tcpd to offer some additional security.

Also:
  - Added syslog messages to sec_channel_server because nothing sees stderr/stdout.
  - Remove extraneous reference to hexdump.h